### PR TITLE
Update 1.4.5.5

### DIFF
--- a/BingoSync/BingoSync.cs
+++ b/BingoSync/BingoSync.cs
@@ -11,7 +11,7 @@ namespace BingoSync
     {
         new public string GetName() => "BingoSync";
 
-        public static string version = "1.4.5.4";
+        public static string version = "1.4.5.5";
         public override string GetVersion() => version;
 
         public override void Initialize()

--- a/BingoSync/BingoSync.cs
+++ b/BingoSync/BingoSync.cs
@@ -12,7 +12,7 @@ namespace BingoSync
     {
         new public string GetName() => "BingoSync";
 
-        public static string version = "1.4.5.0";
+        public static string version = "1.4.5.1";
         public override string GetVersion() => version;
 
         public override void Initialize()

--- a/BingoSync/BingoSync.cs
+++ b/BingoSync/BingoSync.cs
@@ -4,7 +4,6 @@ using BingoSync.Interfaces;
 using BingoSync.ModMenu;
 using BingoSync.Settings;
 using Modding;
-using Newtonsoft.Json;
 
 namespace BingoSync
 {
@@ -12,7 +11,7 @@ namespace BingoSync
     {
         new public string GetName() => "BingoSync";
 
-        public static string version = "1.4.5.2";
+        public static string version = "1.4.5.3";
         public override string GetVersion() => version;
 
         public override void Initialize()

--- a/BingoSync/BingoSync.cs
+++ b/BingoSync/BingoSync.cs
@@ -12,7 +12,7 @@ namespace BingoSync
     {
         new public string GetName() => "BingoSync";
 
-        public static string version = "1.4.4.6";
+        public static string version = "1.4.4.7";
         public override string GetVersion() => version;
 
         private static readonly string DefaultSaveSettings = JsonConvert.SerializeObject(new SaveSettings());

--- a/BingoSync/BingoSync.cs
+++ b/BingoSync/BingoSync.cs
@@ -12,7 +12,7 @@ namespace BingoSync
     {
         new public string GetName() => "BingoSync";
 
-        public static string version = "1.4.4.5";
+        public static string version = "1.4.4.6";
         public override string GetVersion() => version;
 
         private static readonly string DefaultSaveSettings = JsonConvert.SerializeObject(new SaveSettings());

--- a/BingoSync/BingoSync.cs
+++ b/BingoSync/BingoSync.cs
@@ -12,7 +12,7 @@ namespace BingoSync
     {
         new public string GetName() => "BingoSync";
 
-        public static string version = "1.4.5.1";
+        public static string version = "1.4.5.2";
         public override string GetVersion() => version;
 
         public override void Initialize()

--- a/BingoSync/BingoSync.cs
+++ b/BingoSync/BingoSync.cs
@@ -12,10 +12,8 @@ namespace BingoSync
     {
         new public string GetName() => "BingoSync";
 
-        public static string version = "1.4.4.8";
+        public static string version = "1.4.5.0";
         public override string GetVersion() => version;
-
-        private static readonly string DefaultSaveSettings = JsonConvert.SerializeObject(new SaveSettings());
 
         public override void Initialize()
         {
@@ -36,13 +34,9 @@ namespace BingoSync
         public void OnLoadLocal(SaveSettings s)
         {
             GoalCompletionTracker.Variables = s;
-            if(JsonConvert.SerializeObject(s) == DefaultSaveSettings)
-            {
-                return;
-            }
+            GoalCompletionTracker.ClearFinishedGoals();
             if (Controller.GlobalSettings.MarkCompletedGoalsOnLoadSavefile)
             {
-                GoalCompletionTracker.ClearFinishedGoals();
                 GoalCompletionTracker.BroadcastAllGoalStates();
             }
         }

--- a/BingoSync/BingoSync.cs
+++ b/BingoSync/BingoSync.cs
@@ -11,7 +11,7 @@ namespace BingoSync
     {
         new public string GetName() => "BingoSync";
 
-        public static string version = "1.4.5.3";
+        public static string version = "1.4.5.4";
         public override string GetVersion() => version;
 
         public override void Initialize()

--- a/BingoSync/BingoSync.cs
+++ b/BingoSync/BingoSync.cs
@@ -12,7 +12,7 @@ namespace BingoSync
     {
         new public string GetName() => "BingoSync";
 
-        public static string version = "1.4.4.7";
+        public static string version = "1.4.4.8";
         public override string GetVersion() => version;
 
         private static readonly string DefaultSaveSettings = JsonConvert.SerializeObject(new SaveSettings());

--- a/BingoSync/Clients/BingoSyncClient.cs
+++ b/BingoSync/Clients/BingoSyncClient.cs
@@ -230,7 +230,7 @@ namespace BingoSync.Clients
             }, maxRetries, nameof(SetColor));
         }
 
-        public void NewCard(List<BingoGoal> board, bool lockout = true, bool hideCard = true)
+        public void NewCard(List<BingoGoal> board, bool lockout = true, bool hideCard = true, int seed = 0)
         {
             if (GetState() != ClientState.Connected) return;
             var newCard = new NetworkObjectNewCardRequest
@@ -240,7 +240,7 @@ namespace BingoSync.Clients
                 Variant = 18, // but this is also required for custom ???
                 CustomJSON = JsonifyBoard(board),
                 Lockout = !lockout, // false is lockout here for some godforsaken reason
-                Seed = "",
+                Seed = $"{seed}",
                 HideCard = hideCard,
             };
             RetryHelper.RetryWithExponentialBackoff(() =>

--- a/BingoSync/Clients/BingoSyncClient.cs
+++ b/BingoSync/Clients/BingoSyncClient.cs
@@ -188,10 +188,12 @@ namespace BingoSync.Clients
                         var socketJoin = JsonConvert.DeserializeObject<NetworkObjectSocketJoinRequest>(joinRoomResponse.Result);
                         socketKey = socketJoin.SocketKey;
                         RequestPlayerUUID(() => { });
-                        ConnectToBroadcastSocket(socketJoin);
+                        ConnectToBroadcastSocket(socketJoin, () =>
+                        {
+                            SetColor(color);
+                        });
                         RequestAndSetBoard(true, () => { }); 
                         UpdateSettings();
-                        SetColor(color.GetName());
                     });
                 }
                 catch (Exception _ex)
@@ -207,12 +209,13 @@ namespace BingoSync.Clients
             });
         }
 
-        private void SetColor(string color)
+        public void SetColor(Colors color)
         {
+            if (GetState() != ClientState.Connected) return;
             var setColorInput = new NetworkObjectSetColorRequest
             {
                 Room = currentRoomID,
-                Color = color,
+                Color = color.GetName(),
             };
             RetryHelper.RetryWithExponentialBackoff(() =>
             {
@@ -286,14 +289,14 @@ namespace BingoSync.Clients
         public void SendChatMessage(string text)
         {
             if (GetState() != ClientState.Connected) return;
-            var setColorInput = new NetworkObjectChatMessageRequest
+            var chatMessageInput = new NetworkObjectChatMessageRequest
             {
                 Room = currentRoomID,
                 Text = text,
             };
             RetryHelper.RetryWithExponentialBackoff(() =>
             {
-                var payload = JsonConvert.SerializeObject(setColorInput);
+                var payload = JsonConvert.SerializeObject(chatMessageInput);
                 var content = new StringContent(payload, Encoding.UTF8, "application/json");
                 var task = client.PutAsync("api/chat", content);
                 return task.ContinueWith(responseTask =>
@@ -356,7 +359,7 @@ namespace BingoSync.Clients
             });
         }
 
-        private void ConnectToBroadcastSocket(NetworkObjectSocketJoinRequest socketJoin)
+        private void ConnectToBroadcastSocket(NetworkObjectSocketJoinRequest socketJoin, Action callback)
         {
             var socketUri = new Uri("wss://sockets.bingosync.com/broadcast");
             RetryHelper.RetryWithExponentialBackoff(() =>
@@ -377,6 +380,7 @@ namespace BingoSync.Clients
                     {
                         ConnectionStateChanged?.Invoke(this, new ClientStateUpdateInfo() { NewClientState = GetState() });
                         ListenForBoardUpdates(socketJoin);
+                        callback?.Invoke();
                     });
                 });
             }, maxRetries, nameof(ConnectToBroadcastSocket));
@@ -436,7 +440,7 @@ namespace BingoSync.Clients
             if (shouldConnect)
             {
                 Log($"socket is closed, will try to connect again");
-                ConnectToBroadcastSocket(socketJoin);
+                ConnectToBroadcastSocket(socketJoin, () => { });
                 return;
             }
         }

--- a/BingoSync/Clients/BingoSyncClient.cs
+++ b/BingoSync/Clients/BingoSyncClient.cs
@@ -474,7 +474,7 @@ namespace BingoSync.Clients
                     {
                         square.MarkedBy.Add(ColorExtensions.FromName(color));
                     }
-                    GoalUpdateReceived?.Invoke(this, NetworkGoalBroadcastToLocal(goalBroadcast, Board));
+                    GoalUpdateReceived?.Invoke(this, NetworkGoalBroadcastToLocal(goalBroadcast));
                     break;
                 }
             }
@@ -594,13 +594,13 @@ namespace BingoSync.Clients
                 {
                     "chat" => NetworkChatBroadcastToLocal(JsonConvert.DeserializeObject<NetworkObjectChatBroadcast>(unparsedEvent.ToString())),
                     "new-card" => NetworkNewCardBroadcastToLocal(JsonConvert.DeserializeObject<NetworkObjectNewCardBroadcast>(unparsedEvent.ToString())),
-                    "goal" => NetworkGoalBroadcastToLocal(JsonConvert.DeserializeObject<NetworkObjectGoalBroadcast>(unparsedEvent.ToString()), Board),
+                    "goal" => NetworkGoalBroadcastToLocal(JsonConvert.DeserializeObject<NetworkObjectGoalBroadcast>(unparsedEvent.ToString())),
                     "color" => NetworkColorBroadcastToLocal(JsonConvert.DeserializeObject<NetworkObjectColorBroadcast>(unparsedEvent.ToString())),
                     "revealed" => NetworkRevealedBroadcastToLocal(JsonConvert.DeserializeObject<NetworkObjectRevealedBroadcast>(unparsedEvent.ToString())),
                     "connection" => NetworkConnectionBroadcastToLocal(JsonConvert.DeserializeObject<NetworkObjectConnectionBroadcast>(unparsedEvent.ToString())),
                     _ => null,
                 };
-                if(parsedEvent != null)
+                if (parsedEvent != null)
                 {
                     events.Add(parsedEvent);
                 }
@@ -666,7 +666,7 @@ namespace BingoSync.Clients
             };
         }
 
-        private static GoalUpdateEventInfo NetworkGoalBroadcastToLocal(NetworkObjectGoalBroadcast network, BingoBoard board)
+        private static GoalUpdateEventInfo NetworkGoalBroadcastToLocal(NetworkObjectGoalBroadcast network)
         {
             return new GoalUpdateEventInfo()
             {
@@ -674,10 +674,7 @@ namespace BingoSync.Clients
                 Timestamp = network.Timestamp,
                 Color = ColorExtensions.FromName(network.Color),
                 Goal = network.Square.Name,
-                Index = board.AllSquares.Select((square, index) => new { square, index })
-                              .Where(pair => pair.square.Name == network.Square.Name)
-                              .Select(pair => pair.index)
-                              .First(),
+                Index = int.Parse(network.Square.Slot.Substring(4)) - 1,
                 Unmarking = network.Remove,
             };
         }

--- a/BingoSync/Clients/BingoSyncClient.cs
+++ b/BingoSync/Clients/BingoSyncClient.cs
@@ -557,10 +557,7 @@ namespace BingoSync.Clients
                     readTask.ContinueWith(settingsResponse =>
                     {
                         var settings = JsonConvert.DeserializeObject<NetworkObjectRoomSettingsResponse>(settingsResponse.Result);
-                        RoomSettingsReceived(this, new RoomSettings()
-                        {
-                            IsLockout = settings.Settings.LockoutMode == LOCKOUT_MODE
-                        });
+                        RoomSettingsReceived?.Invoke(this, NetworkRoomSettingsToLocal(settings));
                     });
                 });
             }, maxRetries, nameof(UpdateSettings));
@@ -621,6 +618,20 @@ namespace BingoSync.Clients
         }
 
         #region Network objects to internal broadcast objects
+
+        private static RoomSettings NetworkRoomSettingsToLocal(NetworkObjectRoomSettingsResponse network)
+        {
+            return new RoomSettings()
+            {
+                HideCard = network.Settings.HideCard,
+                IsLockout = network.Settings.LockoutMode == LOCKOUT_MODE,
+                GameName = network.Settings.GameName,
+                GameId = network.Settings.GameId,
+                VariantName = network.Settings.VariantName,
+                VariantId = network.Settings.VariantId,
+                Seed = network.Settings.Seed,
+            };
+        }
 
         private static PlayerInfo NetworkPlayerBroadcastToLocal(NetworkObjectPlayer network)
         {
@@ -923,8 +934,20 @@ namespace BingoSync.Clients
     [DataContract]
     class NetworkObjectRoomSettings
     {
+        [JsonProperty("hide_card")]
+        public bool HideCard = true;
         [JsonProperty("lockout_mode")]
         public string LockoutMode = string.Empty;
+        [JsonProperty("game")]
+        public string GameName = string.Empty;
+        [JsonProperty("game_id")]
+        public int GameId = 0;
+        [JsonProperty("variant")]
+        public string VariantName = string.Empty;
+        [JsonProperty("variant_id")]
+        public int VariantId = 0;
+        [JsonProperty("seed")]
+        public int Seed = 0;
     }
 
     [DataContract]

--- a/BingoSync/Clients/EventInfoObjects/RoomSettings.cs
+++ b/BingoSync/Clients/EventInfoObjects/RoomSettings.cs
@@ -2,6 +2,12 @@
 {
     public class RoomSettings
     {
+        public bool HideCard { get; set; }
         public bool IsLockout { get; set; }
+        public string GameName { get; set; }
+        public int GameId { get; set; }
+        public string VariantName { get; set; }
+        public int VariantId { get; set; }
+        public int Seed { get; set; }
     }
 }

--- a/BingoSync/Clients/IRemoteClient.cs
+++ b/BingoSync/Clients/IRemoteClient.cs
@@ -27,7 +27,7 @@ namespace BingoSync.Clients
         public ClientState GetState();
         public void JoinRoom(string roomID, string nickname, string password, Colors color, Action<Exception> callback);
         public void SetColor(Colors color);
-        public void NewCard(List<BingoGoal> board, bool lockout = true, bool hideCard = true);
+        public void NewCard(List<BingoGoal> board, bool lockout = true, bool hideCard = true, int seed = 0);
         public void RevealCard();
         public void SendChatMessage(string text);
         public void SelectSlot(int slot, Colors color, Action errorCallback, bool clear = false);

--- a/BingoSync/Clients/IRemoteClient.cs
+++ b/BingoSync/Clients/IRemoteClient.cs
@@ -26,6 +26,7 @@ namespace BingoSync.Clients
         public void Update();
         public ClientState GetState();
         public void JoinRoom(string roomID, string nickname, string password, Colors color, Action<Exception> callback);
+        public void SetColor(Colors color);
         public void NewCard(List<BingoGoal> board, bool lockout = true, bool hideCard = true);
         public void RevealCard();
         public void SendChatMessage(string text);

--- a/BingoSync/Controller.cs
+++ b/BingoSync/Controller.cs
@@ -148,7 +148,7 @@ namespace BingoSync
         public static void Setup(Action<string> log)
         {
             Log = log;
-            DefaultSession = new Session("Default", new BingoSyncClient(log), true)
+            DefaultSession = new Session("Default", new BingoSyncClient(log), true, GlobalSettings.DefaultSessionUnmarkGoals)
             {
                 AudioNotificationOn = GlobalSettings.AudioNotificationOn
             };

--- a/BingoSync/Controller.cs
+++ b/BingoSync/Controller.cs
@@ -1,4 +1,5 @@
 ﻿using BingoSync.Clients;
+using BingoSync.Clients.EventInfoObjects;
 using BingoSync.CustomGoals;
 using BingoSync.GameUI;
 using BingoSync.Interfaces;
@@ -153,6 +154,8 @@ namespace BingoSync
                 AudioNotificationOn = GlobalSettings.AudioNotificationOn
             };
             ActiveSession = DefaultSession;
+            ActiveSession.OnRoomSettingsReceived -= UpdateLockoutIndicatorOnNewCard;
+            ActiveSession.OnRoomSettingsReceived += UpdateLockoutIndicatorOnNewCard;
             OnBoardUpdate += BingoBoardUI.UpdateGrid;
             OnBoardUpdate += BingoBoardUI.UpdateName;
             OnBoardUpdate += ConfirmTopLeftOnReveal;
@@ -168,6 +171,10 @@ namespace BingoSync
         private static void OnSessionChanged(object _, Session previous)
         {
             RefreshGenerationButtonEnabled();
+            previous.OnRoomSettingsReceived -= UpdateLockoutIndicatorOnNewCard;
+            ActiveSession.OnRoomSettingsReceived -= UpdateLockoutIndicatorOnNewCard;
+            ActiveSession.OnRoomSettingsReceived += UpdateLockoutIndicatorOnNewCard;
+            BingoBoardUI.UpdateLockoutIndicator(ActiveSession.RoomIsLockout);
             RefreshUIWithSession(ActiveSession);
         }
 
@@ -180,6 +187,11 @@ namespace BingoSync
         public static void SetHandModeButtonState(bool handMode)
         {
             MenuUI.HandMode = handMode;
+        }
+
+        public static void UpdateLockoutIndicatorOnNewCard(object sender, RoomSettings settings)
+        {
+            BingoBoardUI.UpdateLockoutIndicator(settings.IsLockout);
         }
 
         public static void ToggleBoardKeybindClicked()

--- a/BingoSync/CustomGoals/GameModesManager.cs
+++ b/BingoSync/CustomGoals/GameModesManager.cs
@@ -222,13 +222,13 @@ namespace BingoSync.CustomGoals
             (int seed, bool isCustomSeed) = Controller.GetCurrentSeed();
             string lockoutString = Controller.MenuIsLockout ? "lockout" : "non-lockout";
             string isCustomSeedString = isCustomSeed ? "set" : "random";
-            Controller.ActiveSession.SendChatMessage($"Generating {Anify(Controller.ActiveGameMode)} board in {lockoutString} mode with {isCustomSeedString} seed {seed}");
+            Controller.ActiveSession.SendChatMessage($"Generating {Anify(Controller.ActiveGameMode)} board in {lockoutString} mode with a {isCustomSeedString} seed");
             List<BingoGoal> board = GameMode.GetErrorBoard();
             if (Controller.ActiveGameMode != string.Empty)
             {
                 board = FindGameModeByDisplayName(Controller.ActiveGameMode).GenerateBoard(seed);
             }
-            Controller.ActiveSession.NewCard(board, Controller.MenuIsLockout);
+            Controller.ActiveSession.NewCard(board, Controller.MenuIsLockout, true, seed);
         }
 
         private static void SetupVanillaGoals()

--- a/BingoSync/GameUI/BingoBoardUI.cs
+++ b/BingoSync/GameUI/BingoBoardUI.cs
@@ -115,6 +115,12 @@ namespace BingoSync.GameUI
             board.boardName.Visibility = Controller.ShowSessionName ? Visibility.Visible : Visibility.Hidden;
         }
 
+        public static void UpdateLockoutIndicator(bool lockout)
+        {
+            string indicator = lockout ? " (L)" : " (NL)";
+            revealCardButton.Content = "Reveal Card" + indicator;
+        }
+
         public static void SetBoardAlpha(float alpha)
         {
             board.SetAlpha(alpha);

--- a/BingoSync/GoalCompletionTracker.cs
+++ b/BingoSync/GoalCompletionTracker.cs
@@ -237,7 +237,7 @@ namespace BingoSync
 
         private static bool IsSolved(BingoSquare square)
         {
-            if (square.Condition.Solved && (!Controller.GlobalSettings.UnmarkGoals || !square.CanUnmark))
+            if (square.Condition.Solved && !square.CanUnmark)
                 return square.Condition.Solved;
             UpdateCondition(square.Condition);
             return square.Condition.Solved;

--- a/BingoSync/Interfaces/OrderedLoader.cs
+++ b/BingoSync/Interfaces/OrderedLoader.cs
@@ -49,6 +49,7 @@ namespace BingoSync.Interfaces
             GameModesManager.Setup(Log);
             MenuUI.Setup(Log);
             BingoBoardUI.Setup(Log);
+            SessionManager.Setup(Log);
 
             // creates a permanent GameObject which calls GlobalKeybindHelper.Update every frame
             GameObject.DontDestroyOnLoad(new GameObject("update_object", [typeof(GlobalKeybindHelper)]));

--- a/BingoSync/Interfaces/SessionManager.cs
+++ b/BingoSync/Interfaces/SessionManager.cs
@@ -80,17 +80,17 @@ namespace BingoSync.Interfaces
         /// <param name="name"></param>
         /// <param name="server"></param>
         /// <param name="isAutoMarking">Whether or not in-game events can mark goals. Marking goals manually with SelectSquare is always possible.</param>
+        /// <param name="isAutoUnmarking">Whether or not in-game events can unmark goals. Unmarking goals manually with SelectSquare is always possible.</param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public static Session CreateSession(string name, Servers server, bool isAutoMarking)
+        public static Session CreateSession(string name, Servers server, bool isAutoMarking, bool isAutoUnmarking)
         {
             IRemoteClient remoteClient = server switch
             {
                 Servers.BingoSync => new BingoSyncClient(Log),
                 _ => throw new NotImplementedException()
             };
-            Session session = new(name, remoteClient, isAutoMarking);
-            return session;
+            return new Session(name, remoteClient, isAutoMarking, isAutoUnmarking);
         }
 
         /// <summary>

--- a/BingoSync/ModMenu/GeneralMenu.cs
+++ b/BingoSync/ModMenu/GeneralMenu.cs
@@ -53,8 +53,12 @@ namespace BingoSync.ModMenu
                 name: "Unmark Goals",
                 description: "Some goals will be unmarked if their conditions are no longer met. WARNING: Can cause board inconsistencies on rare situations",
                 values: ["No", "Yes"],
-                applySetting: (index) => Controller.GlobalSettings.UnmarkGoals = (index == 1),
-                loadSetting: () => Controller.GlobalSettings.UnmarkGoals ? 1 : 0
+                applySetting: (index) =>
+                {
+                    Controller.GlobalSettings.DefaultSessionUnmarkGoals = (index == 1);
+                    Controller.DefaultSession.IsAutoUnmarking = (index == 1);
+                },
+                loadSetting: () => Controller.GlobalSettings.DefaultSessionUnmarkGoals ? 1 : 0
             );
 
             itemSyncSelector = new HorizontalOption(

--- a/BingoSync/Sessions/Session.cs
+++ b/BingoSync/Sessions/Session.cs
@@ -392,7 +392,8 @@ namespace BingoSync.Sessions
 
         private void DoAudioNotification(object sender, GoalUpdateEventInfo goalUpdate)
         {
-            if (goalUpdate.Unmarking || !Board.IsAvailable || !Board.IsRevealed)
+            Session session = sender as Session;
+            if (goalUpdate.Unmarking || !Board.IsAvailable || !Board.IsRevealed || session.HandMode)
             {
                 return;
             }

--- a/BingoSync/Sessions/Session.cs
+++ b/BingoSync/Sessions/Session.cs
@@ -28,6 +28,7 @@ namespace BingoSync.Sessions
             }
         }
         public bool IsAutoMarking { get; set; }
+        public bool IsAutoUnmarking { get; set; } = false;
         public bool BoardIsVisible { get; set; } = true;
         private bool _handMode = false;
         public bool HandMode
@@ -162,12 +163,13 @@ namespace BingoSync.Sessions
 
     #endregion
 
-        public Session(string name, IRemoteClient client, bool markingClient)
+        public Session(string name, IRemoteClient client, bool isAutoMarking, bool isAutoUnmarking)
         {
             SessionName = name;
             _client = client;
             SubscribeEventRefires();
-            IsAutoMarking = markingClient;
+            IsAutoMarking = isAutoMarking;
+            IsAutoUnmarking = isAutoUnmarking;
             _client.SetBoard(Board);
             OnGoalUpdateReceived += DoAudioNotification;
             OnRoomSettingsReceived += ConsumeRoomSettings;
@@ -310,7 +312,10 @@ namespace BingoSync.Sessions
             {
                 if (square.Name == goalUpdate.Name)
                 {
-                    UpdateGoalBySlot(slot, goalUpdate);
+                    if (IsAutoUnmarking || !goalUpdate.Clear)
+                    {
+                        UpdateGoalBySlot(slot, goalUpdate);
+                    }
                 }
                 ++slot;
             }
@@ -377,7 +382,7 @@ namespace BingoSync.Sessions
 
         public void ProcessRoomHistory(Action<List<RoomEventInfo>> callback, Action errorCallback)
         {
-            _client.ProcessRoomHistory(callback, errorCallback);
+           _client.ProcessRoomHistory(callback, errorCallback);
         }
 
         public void DumpDebugInfo()

--- a/BingoSync/Sessions/Session.cs
+++ b/BingoSync/Sessions/Session.cs
@@ -277,6 +277,11 @@ namespace BingoSync.Sessions
             return _client.GetState();
         }
 
+        public void SetColor(Colors color)
+        {
+            _client.SetColor(color);
+        }
+
         public void NewCard(List<BingoGoal> board, bool lockout = true, bool hideCard = true)
         {
             _client.NewCard(board, lockout, hideCard);

--- a/BingoSync/Sessions/Session.cs
+++ b/BingoSync/Sessions/Session.cs
@@ -395,7 +395,7 @@ namespace BingoSync.Sessions
                     break;
 
                 case AudioNotificationCondition.OtherPlayers:
-                    if(goalUpdate.Player.Name != RoomNickname)
+                    if(goalUpdate.Player.UUID != RoomPlayerUUID)
                     {
                         Controller.Audio.Play(ActiveAudioId);
                     }

--- a/BingoSync/Sessions/Session.cs
+++ b/BingoSync/Sessions/Session.cs
@@ -64,6 +64,7 @@ namespace BingoSync.Sessions
             }
         }
         public bool RoomIsLockout { get; set; } = false;
+        public bool RoomHidCardInitially { get; set; } = false;
         public string RoomLink { get; set; } = string.Empty;
         public string RoomNickname { get; set; } = string.Empty;
         public string RoomPassword { get; set; } = string.Empty;
@@ -186,6 +187,7 @@ namespace BingoSync.Sessions
         private void ConsumeRoomSettings(object sender, RoomSettings settings)
         {
             RoomIsLockout = settings.IsLockout;
+            RoomHidCardInitially = settings.HideCard;
         }
 
         private void MarkCompletedGoalsOnNewCard(object sender, NewCardEventInfo newCardEvent)

--- a/BingoSync/Sessions/Session.cs
+++ b/BingoSync/Sessions/Session.cs
@@ -286,9 +286,9 @@ namespace BingoSync.Sessions
             _client.SetColor(color);
         }
 
-        public void NewCard(List<BingoGoal> board, bool lockout = true, bool hideCard = true)
+        public void NewCard(List<BingoGoal> board, bool lockout = true, bool hideCard = true, int seed = 0)
         {
-            _client.NewCard(board, lockout, hideCard);
+            _client.NewCard(board, lockout, hideCard, seed);
         }
 
         public void RevealCard()

--- a/BingoSync/Settings/ModSettings.cs
+++ b/BingoSync/Settings/ModSettings.cs
@@ -24,7 +24,7 @@ namespace BingoSync.Settings
         public KeyBinds Keybinds = new();
         public bool RevealCardOnGameStart = false;
         public bool RevealCardWhenOthersReveal = false;
-        public bool UnmarkGoals = false;
+        public bool DefaultSessionUnmarkGoals = false;
         public string DefaultNickname = "";
         public string DefaultPassword = "";
         public string DefaultColor = "red";


### PR DESCRIPTION
# Bugfixes:
- Audio notifications now differentiate players by UUID instead of by nickname
- Goal condition states now reset correctly when entering a newly created savefile
- Goal update parsing now uses the correct slot even when the goal in question is no longer on the board
- Audio notifications no longer play while in hand mode
# Changes and new features:
- Sessions can now change color while connected
- Room settings broadcast now includes all available information, including board seed and whether or not the board was hidden
- The Reveal Card button now has an indicator for whether the room is in lockout mode or not
- The seed for board generation is now in the Room Settings panel instead of the chat message, so it stays hidden until the card is revealed
